### PR TITLE
Increase logger's level to WARNING in IrrepTables

### DIFF
--- a/irrep/__init__.py
+++ b/irrep/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.10.2"
+__version__ = "1.10.1"
 #from .bandstructure import BandStructure

--- a/irrep/__init__.py
+++ b/irrep/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.10.1"
+__version__ = "1.10.2"
 #from .bandstructure import BandStructure

--- a/irrep/__init__.py
+++ b/irrep/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 #from .bandstructure import BandStructure

--- a/irrep/cli.py
+++ b/irrep/cli.py
@@ -246,7 +246,7 @@ do not hesitate to contact the author:
     "-groupKramers", 
     flag_value=True, 
     default=False, 
-    help="Group wave-functions in pairs of Kramers. Default: True."
+    help="Group wave-functions in pairs of Kramers. Default: False."
 )
 @click.option(
     "-symmetries", 
@@ -345,8 +345,6 @@ def cli(
     # Warning about kpnames
     if kpnames is not None:
         searchcell = True
-
-
 
     elif not searchcell:
         msg = ("Warning: transformation to the convenctional unit "

--- a/irrep/gvectors.py
+++ b/irrep/gvectors.py
@@ -21,7 +21,7 @@ import numpy as np
 import numpy.linalg as la
 Rydberg_eV = 13.605693  # eV
 Hartree_eV = 2 * Rydberg_eV
-from .utility import log_message, orthogonolize
+from .utility import log_message, orthogonalize
 
 
 class NotSymmetryError(RuntimeError):
@@ -477,7 +477,7 @@ def symm_matrix(
         WFinv = right_inverse(WF_other[b1:b2])
         block = np.dot(WFrot[b1:b2,:], WFinv)
         if ortogonalize:
-            block = orthogonolize(block)
+            block = orthogonalize(block)
         block_list.append(block)
     if return_blocks:
         return block_list

--- a/irrep/kpoint.py
+++ b/irrep/kpoint.py
@@ -21,7 +21,7 @@ import numpy as np
 import numpy.linalg as la
 import copy
 from .gvectors import symm_eigenvalues, symm_matrix
-from .utility import compstr, get_block_indices, is_round, format_matrix, log_message, orthogonolize
+from .utility import compstr, get_block_indices, is_round, format_matrix, log_message, orthogonalize
 
 class Kpoint:
     """
@@ -495,7 +495,7 @@ class Kpoint:
         eigenvectors = []
         Eloc = []
         for istate, (b1,b2) in  enumerate(self.block_indices):
-            S_loc = orthogonolize(S[b1:b2, b1:b2], verbosity=verbosity, error_threshold=1e-2, warning_threshold=1e-3)
+            S_loc = orthogonalize(S[b1:b2, b1:b2], verbosity=verbosity, error_threshold=1e-2, warning_threshold=1e-3)
             W, V = la.eig(S_loc)
             for w, v in zip(W, V.T):
                 eigenvalues.append(w)

--- a/irrep/readfiles.py
+++ b/irrep/readfiles.py
@@ -687,7 +687,7 @@ class ParserEspresso:
             reciprocal lattice vector
         kpt : array
             Direct coords of the k-point w.r.t. DFT cell vectors
-         '''
+        '''
 
         kptxml = self.bandstr.findall("ks_energies")[ik]
 

--- a/irrep/tests/test_symsep.py
+++ b/irrep/tests/test_symsep.py
@@ -124,7 +124,8 @@ def check_isymsep(example_dir, command, ref_file, output_file="irrep-output.json
             "irreps.dat",
             "irreptable-template",
             "trace.txt",
-            "irrep-output.json"
+            "irrep-output.json",
+            output_file
     ):
         if os.path.exists(test_output_file):
             os.remove(test_output_file)
@@ -211,7 +212,4 @@ def check_symm_matrix(example_dir, output_file="symm_matrix", ref_file=None, deg
             string+=f"{i}, {j} , {k}, {diff[i,j,k]}, {reference['matrices'][i,j,k]}, {matrices[i,j,k]}\n"
         raise ValueError(string)
     
-    # os.remove(tmp_file)
-            
-
-    
+    os.remove(tmp_file)

--- a/irrep/utility.py
+++ b/irrep/utility.py
@@ -270,7 +270,7 @@ def log_message(msg, verbosity, level):
         print(msg)
 
 
-def orthogonolize(A, warning_threshold=np.inf, error_threshold=np.inf , verbosity=1):
+def orthogonalize(A, warning_threshold=np.inf, error_threshold=np.inf , verbosity=1):
     """
     Orthogonalize a square matrix, using SVD
     

--- a/irreptables/irreptables/__init__.py
+++ b/irreptables/irreptables/__init__.py
@@ -24,7 +24,7 @@ from irrep.utility import str2bool, str2list_space, str_, log_message
 # using a logger to print useful information during debugging,
 # set to logging.INFO to disable debug messages
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.WARNING)
 
 
 class SymopTable:

--- a/irreptables/irreptables/__init__.py
+++ b/irreptables/irreptables/__init__.py
@@ -14,7 +14,7 @@
 ##  e-mail: stepan.tsirkin@physik.uzh.ch                         #
 ##################################################################
 
-__version__="1.1.0"
+__version__="1.1.1"
 
 import os
 import logging


### PR DESCRIPTION
Based on issue #87 , we increase the level of the logger to WARNING in IrrepTables, which means that only WARNING, ERROR and CRITICAL messages will be printed.

In the future, we may consider to unify the loggers in Irrep and IrrepTables.