### PR TITLE
extra parameters for dmn

### DIFF
--- a/irrep/__init__.py
+++ b/irrep/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.11.0"
+__version__ = "1.11.1"
 #from .bandstructure import BandStructure

--- a/irrep/bandstructure.py
+++ b/irrep/bandstructure.py
@@ -899,7 +899,7 @@ class BandStructure:
         return K
 
 
-    def get_dmn(self, grid=None, degen_thresh=1e-2, unitary=True):
+    def get_dmn(self, grid=None, degen_thresh=1e-2, unitary=True, unitary_params={}):
         """
         grid : tuple(int), optional
             the grid of kpoints (3 integers), if None, the grid is determined from the kpoints
@@ -909,6 +909,8 @@ class BandStructure:
              with energy difference smaller than this value are considered
         unitary : bool, optional
             if True, the transformation matrices are made unitary explicitly
+        unitary_params : dict, optional
+            parameters to be passed to :func:`~irrep.utility.orthogonalize`
 
         Returns
         -------
@@ -1013,7 +1015,8 @@ class BandStructure:
                     spinor=K1.spinor,
                     block_ind=block_indices,
                     return_blocks=True,
-                    unitary=unitary
+                    unitary=unitary,
+                    unitary_params=unitary_params,
                 )
                 d_band_blocks[i][isym] = [np.ascontiguousarray(b.T) for b in block_list]
                 # transposed because in irrep WF is row vector, while in dmn it is column vector

--- a/irrep/tests/test_dmn.py
+++ b/irrep/tests/test_dmn.py
@@ -18,7 +18,10 @@ def check_Fe_qe(include_TR):
                                    include_TR=include_TR)
     # bandstructure.spacegroup.show()
                                    
-    data = bandstructure.get_dmn(degen_thresh=1e-3)
+    data = bandstructure.get_dmn(degen_thresh=1e-3, unitary=True, 
+                                 unitary_params={"check_upper": False,
+                                                 "waring_threshold":1e-3,
+                                                 "error_threshold":1e-2}, )
     print (f"number of symmetries: {bandstructure.spacegroup.order}")
     for a in data["d_band_blocks"][:1]:
         for b in a:

--- a/irrep/utility.py
+++ b/irrep/utility.py
@@ -273,7 +273,8 @@ def log_message(msg, verbosity, level):
         print(msg)
 
 
-def orthogonalize(A, warning_threshold=np.inf, error_threshold=np.inf , verbosity=1):
+def orthogonalize(A, warning_threshold=np.inf, error_threshold=np.inf , verbosity=1,
+                  debug_msg=""):
     """
     Orthogonalize a square matrix, using SVD
     
@@ -293,9 +294,9 @@ def orthogonalize(A, warning_threshold=np.inf, error_threshold=np.inf , verbosit
     """
     u, s, vh = np.linalg.svd(A)
     if np.any(np.abs(s - 1) > error_threshold):
-        raise ValueError("Matrix is not orthogonal", A)
+        raise ValueError(f"Matrix is not orthogonal \n {A} \n {debug_msg}")	
     elif np.any(np.abs(s - 1) > warning_threshold):
-        log_message(f"Warning: Matrix is not orthogonal {A}", verbosity, 1)
+        log_message(f"Warning: Matrix is not orthogonal \n {A} \n {debug_msg}", verbosity, 1)
     return u @ vh
 
 def sort_vectors(list_of_vectors):


### PR DESCRIPTION
Allows to externally fine-tune when an error/warning is raised if a transformation matrix appears to be not unitary (in particular for upper band it may be not the case, because of a split irrep)