### PR TITLE
SpaceGroupBare

### DIFF
--- a/irrep/__init__.py
+++ b/irrep/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "1.11.1"
+__version__ = "1.11.2"
 #from .bandstructure import BandStructure

--- a/irrep/bandstructure.py
+++ b/irrep/bandstructure.py
@@ -437,6 +437,10 @@ class BandStructure:
             self.kpoints.append(kp)
         del WF
 
+    @property 
+    def lattice(self):
+        return self.Lattice
+
     @property
     def num_k(self):
         '''Getter for the number of k points'''

--- a/irrep/spacegroup.py
+++ b/irrep/spacegroup.py
@@ -453,7 +453,7 @@ class SymmetryOperation():
         Parameters
         ----------
         alat : float
-            lattice parameter in angstroms.
+            Lattice parameter in angstroms.
 
         Returns
         -------
@@ -700,7 +700,7 @@ class SpaceGroup(SpaceGroupBare):
     trans_thresh : float, default=1e-5
         Threshold used to compare translational parts of symmetries.
     alat : float, default=None
-        lattice parameter in angstroms (quantum espresso convention).
+        Lattice parameter in angstroms (quantum espresso convention).
     from_sym_file : str, default=None
         If provided, the symmetry operations are read from this file.
         (format of pw2wannier90 prefix.sym  file)
@@ -724,7 +724,7 @@ class SpaceGroup(SpaceGroupBare):
         Symbol of the space-group in Hermann-Mauguin notation. 
     number : int 
         Number of the space-group.
-    lattice : array, shape=(3,3) 
+    Lattice : array, shape=(3,3) 
         Each row contains cartesian coordinates of a basis vector forming the 
         unit-cell in real space.
     positions : array
@@ -742,7 +742,7 @@ class SpaceGroup(SpaceGroupBare):
         Translation taking the origin of the unit cell used in the DFT 
         calculation to that of the standard setting.
     alat : float
-        lattice parameter in angstroms (quantum espresso convention).
+        Lattice parameter in angstroms (quantum espresso convention).
     from_sym_file : str, default=None
         if provided, the symmetry operations are read from this file.
         (format of pw2wannier90 prefix.sym  file)
@@ -765,7 +765,7 @@ class SpaceGroup(SpaceGroupBare):
 
     def __init__(
             self,
-            cell=None,
+            cell,
             spinor=True,
             refUC=None,
             shiftUC=None,
@@ -779,7 +779,7 @@ class SpaceGroup(SpaceGroupBare):
             include_TR=False,
             ):                                    
         self.spinor = spinor
-        self.lattice = np.array(cell[0])
+        self.Lattice = np.array(cell[0])
         self.positions = np.array(cell[1])
         self.typat = cell[2]
 
@@ -870,7 +870,7 @@ class SpaceGroup(SpaceGroupBare):
             if provided, the symmetry operations are read from this file.
             (format of pw2wannier90 prefix.sym  file)
         alat : float
-            lattice parameter in angstroms. (quantum espresso convention)
+            Lattice parameter in angstroms. (quantum espresso convention)
         magmom : array(num_atoms, 3)
             Magnetic moments of atoms in the unit cell. 
         include_TR : bool
@@ -938,7 +938,7 @@ class SpaceGroup(SpaceGroupBare):
 
         if from_sym_file is not None:
             print (f"Reading symmetries from file {from_sym_file}")
-            assert alat is not None, "lattice parameter must be provided to read symmetries from file"
+            assert alat is not None, "Lattice parameter must be provided to read symmetries from file"
             rot_cart, trans_cart = read_sym_file(from_sym_file)
             rotations, translations = cart_to_crystal(rot_cart, trans_cart, lattice, alat )
             translation_mod_1=False
@@ -1065,7 +1065,7 @@ class SpaceGroup(SpaceGroupBare):
         filename : str
             Name of the file.
         alat : float, default=None
-            lattice parameter in angstroms. If not specified, the lattice 
+            Lattice parameter in angstroms. If not specified, the lattice 
             parameter is not written to the file.
         """
 
@@ -1073,7 +1073,7 @@ class SpaceGroup(SpaceGroupBare):
             if hasattr(self, 'alat'):
                 alat = self.alat
         if alat is None:
-            warnings.warn("lattice parameter not specified. Symmetry operations will be written assuming A=1")
+            warnings.warn("Lattice parameter not specified. Symmetry operations will be written assuming A=1")
             alat = 1
         with open(filename, "w") as f:
             f.write(" {0} \n".format(len(self.symmetries)))
@@ -1662,7 +1662,7 @@ def cart_to_crystal(rot_cart, trans_cart, lattice, alat):
         Each row contains cartesian coordinates of a basis vector forming the 
         unit-cell in real space.
     alat : float, default=1
-        lattice parameter in angstroms (quantum espresso convention).
+        Lattice parameter in angstroms (quantum espresso convention).
 
     Returns
     -------

--- a/irrep/spacegroup.py
+++ b/irrep/spacegroup.py
@@ -47,7 +47,7 @@ class SymmetryOperation():
         vectors of the unit cell.
     time_reversal : bool, default=False
         `True` if the symmetry operation includes time-reversal.
-    lattice : array, shape=(3,3) 
+    Lattice : array, shape=(3,3) 
         Each row contains cartesian coordinates of a basis vector forming the 
         unit-cell in real space.
     ind : int, default=-1
@@ -70,7 +70,7 @@ class SymmetryOperation():
         vectors of the unit cell.
     time_reversal : bool
         `True` if the symmetry operation includes time-reversal.
-    lattice : array, shape=(3,3) 
+    Lattice : array, shape=(3,3) 
         Each row contains cartesian coordinates of a basis vector forming the 
         unit-cell in real space.
     axis : array, shape=(3,)
@@ -92,12 +92,12 @@ class SymmetryOperation():
         to that in tables.
     """
 
-    def __init__(self, rot, trans, lattice, time_reversal=False, ind=-1, spinor=True, 
+    def __init__(self, rot, trans, Lattice, time_reversal=False, ind=-1, spinor=True, 
                  translation_mod1=True, spinor_rotation=None):
         self.ind = ind
         self.rotation = rot
         self.time_reversal = bool(time_reversal)
-        self.lattice = lattice
+        self.Lattice = Lattice
         self.translation_mod1 = translation_mod1
         self.translation = self.get_transl_mod1(trans)
         self.axis, self.angle, self.inversion = self._get_operation_type()
@@ -115,9 +115,8 @@ class SymmetryOperation():
         self.sign = 1  # May be changed later externally
 
     @property
-    def Lattice(self):
-        warnings.warn("Lattice attribute is deprecated, use lattice instead", DeprecationWarning)
-        return self.lattice
+    def lattice(self):
+        return self.Lattice
 
     def get_transl_mod1(self, t):
         """
@@ -465,8 +464,8 @@ class SymmetryOperation():
             1 line : cartesian translation in units of alat
         """
 
-        Rcart  = self.lattice.T.dot(self.rotation).dot(np.linalg.inv(self.lattice).T)
-        t =  - self.translation @ self.lattice/alat/BOHR   
+        Rcart  = self.Lattice.T.dot(self.rotation).dot(np.linalg.inv(self.Lattice).T)
+        t =  - self.translation @ self.Lattice/alat/BOHR   
 
         arr = np.vstack((Rcart, [t]))
         return "\n"+"".join("   ".join(f"{x:20.15f}" for x in r) + "\n" for r in arr  )
@@ -523,15 +522,15 @@ class SymmetryOperation():
         """
         Calculate the rotation matrix in cartesian coordinates.
         """
-        return self.lattice.T @ self.rotation @ self.lattice_inv.T
+        return self.Lattice.T @ self.rotation @ self.lattice_inv.T
     
     @cached_property
     def translation_cart(self):
-        return self.lattice.T @ self.translation @ self.lattice_inv.T
+        return self.Lattice.T @ self.translation @ self.lattice_inv.T
     
     @cached_property
     def lattice_inv(self):
-        return np.linalg.inv(self.lattice)
+        return np.linalg.inv(self.Lattice)
     
     @cached_property
     def reciprocal_lattice(self):
@@ -578,10 +577,10 @@ class SymmetryOperation():
 
 class SpaceGroupBare():
 
-    def __init__(self, lattice, spinor, rotations, translations, time_reversals, number=0, name="",
+    def __init__(self, Lattice, spinor, rotations, translations, time_reversals, number=0, name="",
                  spinor_rotations=None):
             
-            self.lattice = lattice
+            self.Lattice = Lattice
             self.spinor = spinor
             self.name = name
             self.number = number
@@ -596,7 +595,7 @@ class SpaceGroupBare():
                 self.symmetries.append(SymmetryOperation(rot=rot,
                                                          trans=trans,
                                                          ind=i+1,
-                                                         lattice=self.lattice,
+                                                         Lattice=self.Lattice,
                                                          time_reversal=tr,
                                                          spinor=self.spinor,
                                                          translation_mod1=False,
@@ -608,7 +607,7 @@ class SpaceGroupBare():
         return dictionary with info essential about the spacegroup
         """
         return dict(
-                 lattice=self.lattice, 
+                 Lattice=self.Lattice, 
                  spinor=self.spinor,
                  rotations=[s.rotation for s in self.symmetries],
                  translations=[s.translation for s in self.symmetries],
@@ -645,7 +644,7 @@ class SpaceGroupBare():
         print('Cell vectors in angstroms:\n')
         print('{:^32}'.format('Vectors of DFT cell'))
         for i in range(3):
-            vec1 = self.lattice[i]
+            vec1 = self.Lattice[i]
             s = 'a{:1d} = {:7.4f}  {:7.4f}  {:7.4f}  '.format(i, vec1[0], vec1[1], vec1[2])
             print(s)
         print()
@@ -661,9 +660,8 @@ class SpaceGroupBare():
                 symop.show(refUC=None, shiftUC=None)
 
     @property
-    def Lattice(self):
-        warnings.warn("Lattice attribute is deprecated, use lattice instead", DeprecationWarning)
-        return self.lattice
+    def lattice(self):
+        return self.Lattice
     
     @cached_property
     def lattice_inv(self):
@@ -1016,12 +1014,12 @@ class SpaceGroup(SpaceGroupBare):
         print('')
 
         # Print cell vectors in DFT and reference cells
-        vecs_refUC = np.dot(self.lattice, self.refUC).T
-        #vecs_refUC = np.dot(self.refUC, self.lattice)
+        vecs_refUC = np.dot(self.Lattice, self.refUC).T
+        #vecs_refUC = np.dot(self.refUC, self.Lattice)
         print('Cell vectors in angstroms:\n')
         print('{:^32}|{:^32}'.format('Vectors of DFT cell', 'Vectors of REF. cell'))
         for i in range(3):
-            vec1 = self.lattice[i]
+            vec1 = self.Lattice[i]
             vec2 = vecs_refUC[i]
             s = 'a{:1d} = {:7.4f}  {:7.4f}  {:7.4f}  '.format(i, vec1[0], vec1[1], vec1[2])
             s += '|  '


### PR DESCRIPTION
Created class `SpaceGroupBare` - like `SpaceGroup`, but without anything related to the reference cell. This is needed to be used in other codes, like wannierberri . 

`SpaceGroup` is now a child of `SpaceGroupBare`

Also: 
added properties `lattice` to refer to `Lattice`  In future we may change all variables to start with lower case (capitalized should be only class names)