### PR TITLE
updated f-string syntax for symmops in str2

### DIFF
--- a/irrep/symmetry_operation.py
+++ b/irrep/symmetry_operation.py
@@ -464,6 +464,7 @@ class SymmetryOperation():
         str
             Description to print.
         """
+
         if refUC is None:
             refUC = np.eye(3, dtype=int)
         if shiftUC is None:
@@ -475,13 +476,14 @@ class SymmetryOperation():
         t = self.translation
         S = self.spinor_rotation
         tr = -1 if self.time_reversal else 1
-        sR = "   ".join(" ".join(f"{x:2d}" for x in r) for r in R)
-        st = " ".join(f"{x:10.6f}" for x in t)
+        sR = " ".join(f"{x:>2d}" for row in R for x in row)
+        st = " ".join(f"{x: >10.6f}" for x in t)
+
         if S is not None:
-            sS = "      " + "    ".join(
-                "  ".join(f"{x.real:10.6f} {x.imag:10.6f}" for x in S.reshape(-1)))
+            sS = " ".join(f"{x.real: >10.6f} {x.imag: >10.6f}" for x in S.reshape(-1))
         else:
             sS = ""
+
         if write_tr:
             return f"{sR}     {st}{sS} {tr}\n"
         else:


### PR DESCRIPTION
Making changes to str2() function in symmetry_operation.py (ref #110 ) .All tests passing
```
================================================================================= test session starts ==================================================================================
platform linux -- Python 3.12.7, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/wladerer/github/irrep
plugins: hydra-core-1.3.2
collected 24 items                                                                                                                                                                     

irrep/tests/test_abinit_scalar.py .                                                                                                                                              [  4%]
irrep/tests/test_abinit_spinor.py .                                                                                                                                              [  8%]
irrep/tests/test_dmn.py ....                                                                                                                                                     [ 25%]
irrep/tests/test_ebr_decomposition.py .                                                                                                                                          [ 29%]
irrep/tests/test_espresso_hdf5.py .                                                                                                                                              [ 33%]
irrep/tests/test_espresso_spinor.py ...                                                                                                                                          [ 45%]
irrep/tests/test_refUC.py .                                                                                                                                                      [ 50%]
irrep/tests/test_symmetry_indicators.py .                                                                                                                                        [ 54%]
irrep/tests/test_symsep.py .......                                                                                                                                               [ 83%]
irrep/tests/test_vasp_scalar.py .                                                                                                                                                [ 87%]
irrep/tests/test_vasp_spinor.py .                                                                                                                                                [ 91%]
irrep/tests/test_wannier_scalar.py .                                                                                                                                             [ 95%]
irrep/tests/test_wannier_spinor.py .                                                                                                                                             [100%]

================================================================================= 24 passed in 11.95s ==================================================================================
```

Issue seems to be hard coded spacing in lines 481 and 482 of the original. Let me know if you foresee any potential issues