### PR TITLE
fix(irreptables): correct correptables path in MANIFEST.in

### DIFF
--- a/irreptables/MANIFEST.in
+++ b/irreptables/MANIFEST.in
@@ -1,5 +1,5 @@
 include irreptables/data/tables/*.dat
-include irreptables/correptables/*.dat
+include irreptables/data/correptables/*.dat
 include irreptables/data/ebrs/*ebrs.json
 include irreptables/data/symmetry_indicators/*_indicators*.json
 


### PR DESCRIPTION
The path `irreptables/correptables/*.dat` does not match the actual location `irreptables/data/correptables/*.dat`, causing all 3302 magnetic space group corepresentation files to be silently excluded from the PyPI distribution.

This fix https://github.com/irreducible-representations/irrep/issues/140