### PR TITLE
fix reading kpoint coord from espresso

### DIFF
--- a/irrep/bandstructure.py
+++ b/irrep/bandstructure.py
@@ -682,6 +682,8 @@ class BandStructure:
                 return True
             return False
 
+        kpt_coords = [parser.get_kpt_coord(ik) for ik in kplist]
+        log_message(f'Input files contain {NK} k-points:\n {kpt_coords}', verbosity, 1)
         kplist_noskip = [ik for ik in kplist if not check_skip(parser.get_kpt_coord(ik))]
 
 

--- a/irrep/parsers/espresso.py
+++ b/irrep/parsers/espresso.py
@@ -23,6 +23,9 @@ class ParserEspresso(ParserCommon):
         outp = myroot.find("output")
         self.bandstr = outp.find("band_structure")
         self.spinor = str2bool(self.bandstr.find("noncolin").text)
+        recip_lattice_alat = outp.find("basis_set").find("reciprocal_lattice")
+        recip_lattice_alat = np.array([recip_lattice_alat.find(f"b{i}").text.split() for i in range(1, 4)], dtype=float)
+        self.recip_lattice_alat_inv = np.linalg.inv(recip_lattice_alat)
 
     def parse_header(self, spin_channel=None):
         Ecut0 = float(self.input.find("basis").find("ecutwfc").text)
@@ -103,6 +106,7 @@ class ParserEspresso(ParserCommon):
     def get_kpt_coord(self, ik):
         kptxml = self.bandstr.findall("ks_energies")[ik]
         kpt = np.array(kptxml.find("k_point").text.split(), dtype=float)
+        kpt = kpt.dot(self.recip_lattice_alat_inv)
         return kpt
 
     def parse_kpoint(self, ik, verbosity=0, getE=True, getWF=True):
@@ -133,6 +137,7 @@ class ParserEspresso(ParserCommon):
             checked_files = []
             for extension in ["hdf5", "dat"]:
                 for strcase in [str.lower, str.upper]:
+                    print(f"{ik=}, {wfcname=}, {extension=}, {strcase=}")
                     filename = f"{self.prefix}.save/{strcase(wfcname)}.{extension}"
                     if os.path.exists(filename):
                         if extension == "hdf5":
@@ -152,7 +157,8 @@ class ParserEspresso(ParserCommon):
                             for atr in attrnames:
                                 attributes.append(fWFC.attrs[atr])
 
-                            _gamma_only, _igwx, ik, _ispin, _nbnd, _ngw, _npol, _scale_factor, xk = attributes
+                            _gamma_only, _igwx, ik_read, _ispin, _nbnd, _ngw, _npol, _scale_factor, xk = attributes
+                            assert ik_read == ik + 1, f"Found ik={ik_read} in the wavefunction file {filename}, but expected ik={ik + 1}"
                             kpt = np.array(xk)
                             Miller_Indices = fWFC["MillerIndices"]
                             B = np.array([Miller_Indices.attrs[f"bg{i}"] for i in range(1, 4)])
@@ -178,6 +184,7 @@ class ParserEspresso(ParserCommon):
                             for ib in range(NBin):
                                 rec = fWFC.read_record(f"{npwtot * 2}f8")
                                 WF[ib] = rec[0::2] + 1.0j * rec[1::2]
+                        assert np.allclose(kpt, self.get_kpt_coord(ik)), f"Found kpt[{ik}] {kpt} in the wavefunction file {filename}, but expected {self.get_kpt_coord(ik)}"
                         WF = WF.reshape((NBin, npw, nspinor), order="F")
                         return WF, Energy, kg, kpt
                     checked_files.append(filename)

--- a/irrep/parsers/gpaw.py
+++ b/irrep/parsers/gpaw.py
@@ -63,6 +63,7 @@ class ParserGPAW(ParserCommon):
         log_message(f"shapes of WFupdw: {[wf.shape for wf in WFupdw]}", self.verbosity, 2)
         ngx, ngy, ngz = WFupdw[0].shape[1:]
         kpt = self.calculator.get_ibz_k_points()[ik]
+        assert np.allclose(kpt, self.get_kpt_coord(ik)), f"Found kpt[{ik}] {kpt} in the wavefunction file, but expected {self.get_kpt_coord(ik)}"
         kg, eKG = calc_gvectors(
             kpt,
             RecLattice,

--- a/irrep/parsers/vasp.py
+++ b/irrep/parsers/vasp.py
@@ -134,6 +134,7 @@ class ParserVasp(ParserCommon):
             assert npw % 2 == 0, f"odd number of coefs {npw} for spinor wavefunctions"
         npw //= nspinor
         kpt = r[1:4]
+        assert np.allclose(kpt, self.get_kpt_coord(ik)), f"Found kpt[{ik}] {kpt} in the wavefunction file, but expected {self.get_kpt_coord(ik)}"
         if getE:
             Energy = np.array(r[4: 4 + NBin * 3]).reshape(NBin, 3)[:, 0]
         else:

--- a/irrep/tests/test_gpaw.py
+++ b/irrep/tests/test_gpaw.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 from irrep.bandstructure import BandStructure
 from pytest import approx
+from .conftest import TEST_FILES_PATH
 
 
 
@@ -10,7 +11,7 @@ from pytest import approx
 
 @pytest.mark.parametrize("spinor", [True, False])
 def test_gpaw_spinorbit(spinor):
-    calc = GPAW("../../examples/gpaw/Bi-gamma.gpw")
+    calc = GPAW(f"{TEST_FILES_PATH}/gpaw/Bi-gamma.gpw")
 
     nspinor = 2 if spinor else 1
 
@@ -26,7 +27,7 @@ def test_gpaw_spinorbit(spinor):
                                   read_paw=not spinor,  # for now, read_pae does not work with spinor calculations
                                   search_cell=True,
                                   kplist=[0])
-    output_file = "../../examples/gpaw/Bi-gamma_bandstructure.pickle"
+    output_file = f"{TEST_FILES_PATH}/gpaw/Bi-gamma_bandstructure.pickle"
     bandstructure.pickle(output_file)
     # print ("Bandstructure",bandstructure)
     bandstructure.spacegroup.show()


### PR DESCRIPTION
there was a bug that `PardserEspresso.get_kpt_coord(self, ik)` was reading kpoint coordinate in "2piu/alat" and did not convert to reduced coordinates.  While `parse_kpoint` was reading correctly with transformation.  
