### PR TITLE
Corrected parsing of implicit multiplication in sympify

### DIFF
--- a/irrep/spacegroup.py
+++ b/irrep/spacegroup.py
@@ -30,6 +30,8 @@ import os
 
 from pyxtal import Group
 from sympy import Matrix, sympify
+from sympy.parsing.sympy_parser import parse_expr, standard_transformations, implicit_multiplication_application
+
 
 
 class SpaceGroup:
@@ -1055,7 +1057,8 @@ class SpaceGroup:
         for sim_vector in conventional_wyckoffs:
 
             # sim_vector is a string on array shape change to numeric or simbolic
-            vector = Matrix([sympify(v) for v in sim_vector.split(',')])
+            _TRANSFORMS = standard_transformations + (implicit_multiplication_application,)
+            vector = Matrix([parse_expr(v, transformations=_TRANSFORMS) for v in sim_vector.split(',')])
             wyckoff_new_base = inv_transformation_matrix * (vector - origin_shift)
 
             # Change to string again

--- a/irrep/tests/test_spacegroup.py
+++ b/irrep/tests/test_spacegroup.py
@@ -5,7 +5,8 @@ from irrep.tests.test_dmn import REF_FILES_PATH, TMP_FILES_PATH
 
 from .conftest import REF_DATA_PATH, TMP_DATA_PATH
 from irrep.utility import group_numbers
-
+import sympy
+from sympy.parsing.sympy_parser import parse_expr, standard_transformations, implicit_multiplication_application
 
 a = 4.456
 c = 5.926
@@ -128,5 +129,50 @@ def test_wyckoff_positions():
     return
 
 
-test_conventional_wyckoff_positions()
-test_wyckoff_positions()
+def test_wyckoff_positions_2():
+    """ Test for MnTe, which has a spacegroup containing WP of the form (2x,...,...), which can break the sympify parser """
+    a = 4.17349018
+
+    cell = (
+        np.array([
+            [a, 0, 0],
+            [-a / 2, np.sqrt(3) * a / 2, 0],
+            [0, 0, 6.75345133],
+        ]),
+
+        np.array([
+            [0, 0, 0],
+            [0, 0, 0.5],
+            [1 / 3, 2 / 3, 1 / 4],
+            [2 / 3, 1 / 3, 3 / 4],
+        ]),
+
+        np.array([25, 25, 52, 52]),
+    )
+
+    MnTe_wyckoffs = SpaceGroup.wyckoff_positions(cell)
+
+    first_MnTe_wyckoffs = [
+        [1 / 3, 2 / 3, 0.75],
+        [1 / 3, 2 / 3, 0.25],
+        [0, 0, 0.25],
+        [0, 0, 0],
+    ]
+    print(MnTe_wyckoffs)
+    # Testing the first 4 wp because they are numerical arrays not symbols
+    for i, wp in enumerate(MnTe_wyckoffs[-4:]):
+        numerical_wp = wp.split(',')
+        numerical_wp = [ float(x) for x in numerical_wp]
+        assert np.allclose(numerical_wp, first_MnTe_wyckoffs[i])
+    # checking correct parsing of the symbolic strings
+    assert MnTe_wyckoffs[4].split(',')[1] == '2.0*x'
+    return
+    
+
+def test_implicit_multiplication_parsing():
+    """test lines 1060-1061 of spacegroup.py, which use parse_expr with implicit multiplication"""
+    x, y = sympy.symbols('x y')
+    _TRANSFORMS = standard_transformations + (implicit_multiplication_application,)
+    assert parse_expr('2x', transformations=_TRANSFORMS) == 2 * x
+    assert parse_expr('-2x+1', transformations=_TRANSFORMS) == -2 * x + 1
+    assert parse_expr('2x-y', transformations=_TRANSFORMS) == 2 * x - y


### PR DESCRIPTION
# Description 
Internally, `spacegroup.wyckoff_positions` uses `pyxtal` to get the conventional Wyckoff positions, and they are given in a format with implicit multiplication, i.e. `(2x, 0, 0.5)` in place of `(2.00*x, 0.0, 0.5)`.  However `simpy.sympify`, used for the symbolic transformation, is not able to parse implicit multiplication, and hence crashes. This happens for example for MnTe with space group 194. This was corrected by using the `parse_expr` method from `sympy.parsing.sympy_parser`, which accepts an implicit multiplication transform.

# Changes
- Changed the parsing from `simpify` to `parse_expr`,
- Added a test covering the corrected bug with MnTe, which fails without the fix.